### PR TITLE
Added American Journal of Freestanding Research Psychology

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,24 @@
 This is a repository to share some cool and Legal deep web links, feel free to contribute! 
 
 
-Phobos - http://phobosxilamwcg75xt22id7aywkzol6q6rfl2flipcqoc4e4ahima5id.onion/
+## Phobos - 
 
-Bitcoin Mining - http://quantumzij3ycjw47hfxzbgd3j6m6xx2rcsld4jyolmnmfu7vbmuqnad.onion/
+http://phobosxilamwcg75xt22id7aywkzol6q6rfl2flipcqoc4e4ahima5id.onion/
 
-Publeaks - http://eozjdgpnnmvcfn3drxtirjcn5c27ydkzqlzn4iptam54eewhji6qlqqd.onion/#/
+## Bitcoin Mining -
+
+http://quantumzij3ycjw47hfxzbgd3j6m6xx2rcsld4jyolmnmfu7vbmuqnad.onion/
+
+## Publeaks - 
+
+http://eozjdgpnnmvcfn3drxtirjcn5c27ydkzqlzn4iptam54eewhji6qlqqd.onion/#/
+
+## American Journal of Freestanding Research Psychology - 
+
+Research papers are notoriously difficult to access, especially in academic fields like philosophy, science, and psychology. Journals are expensive to subscribe to, and buying reading right to single articles gets expensive fast. The onion-based journal aims to avoid that limitation. It’s actually legal to use, too, since all papers featured on the site were submitted by their original authors in an effort to make knowledge more accessible to the world.
+
+https://qtsdq6tkszhxost2.onion
+
+
+
 


### PR DESCRIPTION
Research papers are notoriously difficult to access, especially in academic fields like philosophy, science, and psychology. Journals are expensive to subscribe to, and buying reading right to single articles gets expensive fast. The onion-based journal aims to avoid that limitation. It’s actually legal to use, too, since all papers featured on the site were submitted by their original authors in an effort to make knowledge more accessible to the world.

Added the link and also updated the Readme , Please merge the pull request under hacktoberfest @carinebatista 